### PR TITLE
Correct check for $opt_n, stat kernels separately

### DIFF
--- a/update-kernel
+++ b/update-kernel
@@ -85,7 +85,7 @@ update_kernel()
     else
         echo "Install new $target"
     fi
-    if [ -z "$opt_n" ];then
+    if [ -n "$opt_n" ];then
         return;
     fi
     $ASROOT chown root:wheel $new
@@ -117,5 +117,8 @@ elif [ -z "$opt_f" ] && compare_kernel $TMPFILE $TARGET ; then
     stat_kernel $TARGET
 else
     update_kernel $TMPFILE $TARGET $BACKUP
-    stat_kernel $BACKUP $TARGET
+    echo "Old:"
+    stat_kernel $BACKUP
+    echo "New:"
+    stat_kernel $TARGET
 fi


### PR DESCRIPTION
1. Pretty sure the `-z` check for $opt_n was a typo. I.e. we do not want
to return if this is not a dry-run. And the default is not a dry-run.
Perhaps could have misunderstood this though?

2. I don't see how `stat_kernel` is meant to handle two arguments so
call it twice with each argument separately.